### PR TITLE
fix(workflows): Point to main branch instead of master

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "Code scanning - action"
 
 on:
   push:
-    branches: [master, ]
+    branches: [main, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 12 * * 3'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint Code Base
 on:
   push:
     branches-ignore:
-      - 'master'
+      - "main"
 jobs:
   build:
     name: Lint Code Base


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Point to main branch instead of master

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`main` is the default branch in this repository now