### PR TITLE
fix(puppeteer): To run `browser.close()` when Puppeteer fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,10 @@ async function main () {
     console.log(response)
     await page.type('.TimeTrackingWidget__form input', '8')
     await page.click('.js-save-timesheet-button-wrap button')
-    browser.close()
   } catch (error) {
     console.error(error)
+  } finally {
+    browser.close()
   }
 }
 


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To run `browser.close()` when Puppeteer fails

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid endless Github Action execution when Puppeteer execution fails

Fix #40 