### PR TITLE
ci(auto-merge): Remove auto-merge GitHub App config file

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,6 +1,0 @@
-minApprovals:
-  COLLABORATOR: 0
-requiredLabels:
-- dependencies
-mergeMethod: squash
-reportStatus: true


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Remove auto-merge GitHub App config file

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`auto-merge` GitHub App has been deleted from this repository so, `auto-merge` config file is not used anymore.

Fix #42