### PR TITLE
feat(github-action): run when PR is labeled with 'test-puppeteer'

### DIFF
--- a/.github/workflows/bamboohr-puppeteer.yml
+++ b/.github/workflows/bamboohr-puppeteer.yml
@@ -1,12 +1,12 @@
 name: BambooHR with Puppeteer
 on:
-  push:
-    branches:
-      - "test-*"
+  pull_request:
+    types: ['labeled']
   schedule:
     - cron: '0 8 * * 1-5'
 jobs:
   puppeteer:
+    if: contains(github.event.pull_request.labels.*.name, 'test-puppeteer')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To force running workflow in a PR when is labeled with `test-puppeteer`

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To test workflows without having to wait for `cron`` event