### PR TITLE
revert(github-action-cron): remove test cron from github action workflow

### DIFF
--- a/.github/workflows/bamboohr-puppeteer.yml
+++ b/.github/workflows/bamboohr-puppeteer.yml
@@ -4,7 +4,6 @@ on:
     types: ['labeled']
   schedule:
     - cron: '0 8 * * 1-5'
-    - cron: '32 19 * * 1-5'
 jobs:
   puppeteer:
     if: contains(github.event.pull_request.labels.*.name, 'test-puppeteer')


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Removes `cron` from GitHub Action workflow, added in the past for testing purposes

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clean up